### PR TITLE
Add current dir to include search path (-I.) so that the includes in …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ TMPDIR ?= /tmp
 
 ### The compiler options:
 
-export CFLAGS	= $(call PKGCFG,cflags) 
+export CFLAGS	= $(call PKGCFG,cflags) -I.
 export CXXFLAGS = $(call PKGCFG,cxxflags)
 
 ifeq ($(CFLAGS),)


### PR DESCRIPTION
…amports are found correctly.